### PR TITLE
Retry failed case for robot framework

### DIFF
--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -68,7 +68,8 @@ class _BaseSettings(object):
                  'ConsoleColors'    : ('consolecolors', 'AUTO'),
                  'StdOut'           : ('stdout', None),
                  'StdErr'           : ('stderr', None),
-                 'XUnitSkipNonCritical' : ('xunitskipnoncritical', False)}
+                 'XUnitSkipNonCritical' : ('xunitskipnoncritical', False),
+                 'Retry':('retry',1)}
     _output_opts = ['Output', 'Log', 'Report', 'XUnit', 'DebugFile']
 
     def __init__(self, options=None, **extra_options):

--- a/src/robot/model/itemlist.py
+++ b/src/robot/model/itemlist.py
@@ -68,8 +68,19 @@ class ItemList(object):
         self._items = ()
 
     def visit(self, visitor):
-        for item in self._items:
-            item.visit(visitor)
+        for item in self:
+            if self.__module__ == 'robot.model.testcase' and hasattr(visitor,"_context"):
+                testStatus = ''
+                for i in range(0,int(visitor._settings._opts['Retry'])):
+                    if testStatus != 'PASS':
+                        if item.name in visitor._executed_tests:
+                            visitor._executed_tests.pop(item.name)
+                        item.visit(visitor)
+                        testStatus = visitor._context.variables['${PREV_TEST_STATUS}']
+                    else:
+                        break
+            else:
+                item.visit(visitor)
 
     def __iter__(self):
         return iter(self._items)


### PR DESCRIPTION
Main change: add new option for retry failed cases in robot framework.

Usage:
- robot test.robot: same as offical robot framework
- robot --retry 1 test.robot: same as offical robot framework
- robot --retry 2 test.robot: retry failed cases for one time
- robot --retry N test.robot: retry failed cases for N-1 times

Note:
- Only retry failed cases
- All failed cases will be retried
- Retry until either case is passed or maxium number is achived
- In robot logs, only display result of the last run; In console log, display results of all runs.